### PR TITLE
Disable no-param-reassign - rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
       "max-len": ["warn", 120],
       "@typescript-eslint/no-inferrable-types": "off",
       "no-underscore-dangle": ["error", {"allowAfterThis": true}],
-      "prefer-destructuring": ["off"]
+      "prefer-destructuring": ["off"],
+      "@typescript-eslint/no-param-reassign": "off"
     }
 };


### PR DESCRIPTION
https://eslint.org/docs/rules/no-param-reassign

Die Regel existiert, damit Objekte (die in JS grundsätzlich per Referenz übergeben werden) nicht von Funktionen geändert werden können, die dafür nicht vorgesehen sind. Damit soll verhindert werden, dass der Kontrollfluss unübersichtlich wird. Eine sehr noble Absicht, die die Regel von der Theorie her sehr wertvoll macht und sie ich sofort unterschreiben würde.

Leider ist sie praktisch ist sie kaum haltbar, da es einfach an sinnvollen Alternativen mangelt. JS bietet nun mal keine Möglichkeit Objekte als Wert zu übergeben (anders als zB PHP!). Man schreibt ja *ständig* so etwas, gerade wenn man man mit rxjs arbeitet:

```
.pipe(
        map(bData => {
          bData.id = bookletId;
          return bData;
        }),
```
oder

```
    Object.keys(fileList).forEach(type => {
      // eslint-disable-next-line no-param-reassign
      fileList[type] = fileList[type].map(files => this.addFrontendChecksToFile(files));
    });
```
Ständig hat man im Kontext von ´Array.forEach´ oder ´rxjs/map´ oder ´Array.map´ oder so kleine Funktionen in denen Objekte manipuliert werden *sollen*.

Natürlich kann man die Regel umgehen, indem man das Objekt erst kopiert:
```
.pipe(
        map(bData => {
          const bDataCopy = Object.assign({}, bData);
          bDataCopy.id = bookletId;
          return bDataCopy;
        }),
```
Aber was hat man davon? Eine Zeile mehr, sinnlos Speicher alloziert und am am Ende kein bisschen bessere Übersicht. *Und* das ist ja nur eine Shallow-Copy. Für Deep-Copies gibt es bekannter maßen keinen JS Befehl, da müsste man rekursiv runtergehen, denn sonst könnte man, an der Regel vorbei, trotzdem noch doch Unterobjekte des Originals manipulieren.

--

Zusätzlich sinnlos wird die Regel bei Argumenten atomaren Typs:
```
  getNextUnlockedUnitSequenceId(currentUnitSequenceId: number): number {
    currentUnitSequenceId += 1;
     // more logic and stuff
    return currentUnitSequenceId;
  }
```
Selbst hier greift sie, wo sie durch *nichts* zu rechtfertigen ist, denn atomare Typen werden in jS *immer* als wert, nicht als Referenz übergeben. Es ist also nicht möglich, hier versehentlich die Originalvariable zu manipulieren. 

--

Fazit: Mir scheint die Regel aus Programmierparadigmen abgeleitet, die aus anderen Programmiersprachen (C, Rust, PHP, Java(?)) kommen aber in JS überhaupt nicht sinnvoll umzusetzen sind (leider!). So sind Verstöße nicht sinnvoll zu vermeiden und die Regel erzeugt nur Bloat und Verwirrung.