### PR TITLE
Allow usage of classes before they are defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
       "max-len": ["warn", 120],
       "@typescript-eslint/no-inferrable-types": "off",
       "no-underscore-dangle": ["error", {"allowAfterThis": true}],
-      "prefer-destructuring": ["off"]
+      "prefer-destructuring": ["off"],
+      "@typescript-eslint/no-use-before-define": ["error", { "classes": false }]
     }
 };


### PR DESCRIPTION
https://eslint.org/docs/rules/no-use-before-define

Macht die Regel überhaupt Sinn bei Typescript. Es wird doch eh alles durch den Compiler gejagt?

In dem Fall habe ich die Regel drin gelassen, sie aber für Klassendefinitionen abgestellt.