### PR TITLE
Explicit member accessibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,15 @@ module.exports = {
     "prefer-destructuring": ["off"],
     "@typescript-eslint/no-unused-expressions": [2, {"allowTernary": true}],
     "no-plusplus": ["error", {"allowForLoopAfterthoughts": true}],
-    "no-param-reassign": ["error", {"props": false}]
+    "no-param-reassign": ["error", {"props": false}],
+    "@typescript-eslint/explicit-member-accessibility": [
+      "error",
+      {
+        accessibility: 'no-public',
+        overrides: {
+          properties: 'explicit'
+        }
+      }
+    ]
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,48 +1,48 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "airbnb-typescript/base",
-        "plugin:@typescript-eslint/recommended"
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "airbnb-typescript/base",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module",
+    "project": "./tsconfig.base.json"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "@typescript-eslint/comma-dangle": ["error", "never"],
+    "import/prefer-default-export": "off",
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+    "@typescript-eslint/lines-between-class-members": [
+      "error", "always",
+      {
+        "exceptAfterSingleLine": true
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module",
-        "project": "./tsconfig.base.json"
-    },
-    "plugins": [
-        "@typescript-eslint"
+    "operator-linebreak": [2, "after"],
+    "@typescript-eslint/indent": [
+      "error", 2,
+      {
+        "SwitchCase": 1,
+        "FunctionExpression": {
+          "parameters": "first"
+        }
+      }
     ],
-    "rules": {
-      "@typescript-eslint/comma-dangle": ["error", "never"],
-      "import/prefer-default-export": "off",
-      "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
-      "@typescript-eslint/lines-between-class-members": [
-        "error", "always",
-        {
-          "exceptAfterSingleLine": true
-        }
-      ],
-      "operator-linebreak": [2, "after"],
-      "@typescript-eslint/indent": [
-        "error", 2,
-        {
-          "SwitchCase": 1,
-          "FunctionExpression": {
-              "parameters": "first"
-          }
-        }
-      ],
-      "arrow-parens": ["error", "as-needed"],
-      "max-len": ["warn", 120],
-      "@typescript-eslint/no-inferrable-types": "off",
-      "no-underscore-dangle": ["error", {"allowAfterThis": true}],
-      "prefer-destructuring": ["off"],
-      "@typescript-eslint/no-unused-expressions": [2, {"allowTernary": true}],
-      "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-      "no-param-reassign": ["error", { "props": false }]
-    }
+    "arrow-parens": ["error", "as-needed"],
+    "max-len": ["warn", 120],
+    "@typescript-eslint/no-inferrable-types": "off",
+    "no-underscore-dangle": ["error", {"allowAfterThis": true}],
+    "prefer-destructuring": ["off"],
+    "@typescript-eslint/no-unused-expressions": [2, {"allowTernary": true}],
+    "no-plusplus": ["error", {"allowForLoopAfterthoughts": true}],
+    "no-param-reassign": ["error", {"props": false}]
+  }
 };


### PR DESCRIPTION
Diesmal schlage ich zur Abwechslung mal vor, eine Regel einzuführen ;)

Und zwar ist es so, dass bei Typescript Klassenvariablen und -Methoden per default public sind. Gibt man also keinen scope an, ist es public.

Das hier ist also beides das gleiche:


```
export class BookletService {
  booklets: Observable<Booklet|BookletError>[] = [];
```
und
```
export class BookletService {
  public booklets: Observable<Booklet|BookletError>[] = [];
```

Siehe: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md

Beides wird auch in unserem Code benutzt. Ich würde das regeln wollen. Mein Vorschlag hier ist, dass das `public` wegzulassen ist. Alternativ könnte man es auch verpflichtend machen, das fände ich (fast) genauso gut.

Ich bitte um Abstimmung.