### PR TITLE
Allow long form in object definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = {
         }
       }
     ],
-    "no-use-before-define": ["error", { "classes": true }]
+    "no-use-before-define": ["error", { "classes": true }],
+    "object-shorthand": ["off"]
   }
 };


### PR DESCRIPTION
Wir haben bei ESLint ja https://eslint.org/docs/rules/prefer-destructuring bereits abgestellt. Ich würde die ähnliche Regel https://eslint.org/docs/rules/object-shorthand ebenfalls gerne abschalten.

Das sind beides Regeln die syntaktische Kurzformen erzwingen. Ich würde es aber gerne offen lassen, das selbst zu entscheiden. Wenn wir das einheitlich machen wollen, plädiere ich für die Langform.

Beispiel:
Ich will weiterhin schreiben können:
function(text: string) {
    const exampleObject = {
      text: text
    };

statt
const exampleObject = {
      text
    };