### PR TITLE
[codex] Finalize ESLint flat-config migration for ESLint 9/10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,16 @@
 # @iqb/eslint-config
 
-ESLint rules for TypeScript and JavaScript development, with rules agreed by IQB developers. Optimized for ESLint 9 (Flat Config) and ESM.
-
-## Features
-
-- **Flat Config Support**: Native support for the new ESLint configuration format.
-- **TypeScript & JavaScript**: First-class support for both.
-- **SonarJS Integration**: Advanced code quality and bug detection.
-- **JSDoc Linting**: Ensuring well-documented APIs.
-- **Perfectionist**: Consistent sorting and organization of code.
-- **ESM Native**: Fast and compatible with modern tools.
+ESLint rules for TypeScript and JavaScript development, with rules agreed by IQB developers. Optimized for ESLint Flat Config (ESLint 9 and 10) and ESM.
 
 ## Installation
 
-Run on command line:
 ```bash
 npm install @iqb/eslint-config --save-dev
 ```
 
-## Usage (ESLint 9+)
+## Usage (ESLint 9+ / 10+)
 
-ESLint 9 uses the new "Flat Config" format. Create an `eslint.config.js` in your project root. Since this package is ESM-based, your `eslint.config.js` should also use ESM (`import`/`export`).
+Create an `eslint.config.js` in your project root. This package is ESM-based, so your ESLint config should also use ESM (`import`/`export`).
 
 ### TypeScript
 
@@ -32,10 +22,10 @@ export default [
   {
     languageOptions: {
       parserOptions: {
-        project: './tsconfig.json', // Required for type-aware rules
-        tsconfigRootDir: import.meta.dirname,
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname
       },
-    },
+    }
   },
   {
     rules: {
@@ -60,19 +50,30 @@ export default [
 ];
 ```
 
-## Internal Development
+## Migration from legacy `.eslintrc*`
 
-### Run Linting
-```bash
-npm run lint
+This package no longer supports legacy `extends` usage in `package.json` for new setups.
+
+Old (legacy):
+
+```json
+{
+  "eslintConfig": {
+    "extends": "@iqb/eslint-config"
+  }
+}
 ```
 
-### Run Tests
-```bash
-npm run test
+New (flat config):
+
+```javascript
+import iqbConfig from '@iqb/eslint-config';
+
+export default [...iqbConfig];
 ```
 
-## Troubleshooting
+## Compatibility
 
-In case you are not using *Solution Style tsconfig.json* files, make sure the `project` path in `parserOptions` points to your main `tsconfig.json` file.
-For ESM environments, use `import.meta.dirname` instead of `__dirname`.
+- ESLint: `^9.0.0 || ^10.0.0`
+- `@eslint/js`: `^9.0.0 || ^10.0.0`
+- `typescript-eslint`: `^8.0.0`

--- a/README.md
+++ b/README.md
@@ -1,44 +1,78 @@
-[![npm](https://img.shields.io/npm/v/@iqb/eslint-config.svg?style=flat-square)](https://www.npmjs.com/package/@iqb/eslint-config)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
+# @iqb/eslint-config
 
-# eslint-config
+ESLint rules for TypeScript and JavaScript development, with rules agreed by IQB developers. Optimized for ESLint 9 (Flat Config) and ESM.
 
-ESLint rules for typescript and javascript development, with rules agreed by
-IQB developers.
+## Features
+
+- **Flat Config Support**: Native support for the new ESLint configuration format.
+- **TypeScript & JavaScript**: First-class support for both.
+- **SonarJS Integration**: Advanced code quality and bug detection.
+- **JSDoc Linting**: Ensuring well-documented APIs.
+- **Perfectionist**: Consistent sorting and organization of code.
+- **ESM Native**: Fast and compatible with modern tools.
 
 ## Installation
 
 Run on command line:
-```
+```bash
 npm install @iqb/eslint-config --save-dev
 ```
 
-Put the following lines in your package.json, depending on whether you use Typescript or Javascript.
-#### Typescript
-```
-"eslintConfig": {
-  "extends": "@iqb/eslint-config"
-},
-```
-#### Javascript
-```
-"eslintConfig": {
-  "extends": "@iqb/eslint-config/javascript"
-},
+## Usage (ESLint 9+)
+
+ESLint 9 uses the new "Flat Config" format. Create an `eslint.config.js` in your project root. Since this package is ESM-based, your `eslint.config.js` should also use ESM (`import`/`export`).
+
+### TypeScript
+
+```javascript
+import iqbConfig from '@iqb/eslint-config';
+
+export default [
+  ...iqbConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json', // Required for type-aware rules
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    rules: {
+      // Your project-specific overrides
+    }
+  }
+];
 ```
 
+### JavaScript
+
+```javascript
+import iqbJavaScriptConfig from '@iqb/eslint-config/javascript';
+
+export default [
+  ...iqbJavaScriptConfig,
+  {
+    rules: {
+      // Your project-specific overrides
+    }
+  }
+];
+```
+
+## Internal Development
+
+### Run Linting
+```bash
+npm run lint
+```
+
+### Run Tests
+```bash
+npm run test
+```
 
 ## Troubleshooting
 
-In case you are not using *Solution Style tsconfig.json* files (older Angular versions do this; when you
-have a tsconfig.base.json in your project root, you are using solution style), add *parserOptions/project*
-to your package.json and make sure the path points to your main *tsconfig.json* file.
-
-```
-"eslintConfig": {
-  "extends": "@iqb/eslint-config",
-  "parserOptions": {
-    "project": "./tsconfig.json"
-  }
-},
-```
+In case you are not using *Solution Style tsconfig.json* files, make sure the `project` path in `parserOptions` points to your main `tsconfig.json` file.
+For ESM environments, use `import.meta.dirname` instead of `__dirname`.

--- a/index.js
+++ b/index.js
@@ -1,67 +1,82 @@
-module.exports = {
-  "env": {
-    "browser": true,
-    "es2021": true
-  },
-  "extends": [
-    "airbnb-base",
-    "airbnb-typescript/base",
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
-  ],
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "ecmaVersion": 12,
-    "sourceType": "module",
-    "project": "./tsconfig.json"
-  },
-  "plugins": [
-    "@typescript-eslint"
-  ],
-  "rules": {
-    "@typescript-eslint/comma-dangle": ["error", "never"],
-    "import/prefer-default-export": "off",
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
-    "@typescript-eslint/lines-between-class-members": [
-      "error", "always",
-      {
-        "exceptAfterSingleLine": true
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import globals from 'globals';
+import sonarjs from 'eslint-plugin-sonarjs';
+import jsdoc from 'eslint-plugin-jsdoc';
+import perfectionist from 'eslint-plugin-perfectionist';
+import stylistic from '@stylistic/eslint-plugin';
+import importX from 'eslint-plugin-import-x';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  sonarjs.configs.recommended,
+  jsdoc.configs['flat/recommended'],
+  perfectionist.configs['recommended-natural'],
+  stylistic.configs.recommended,
+  importX.flatConfigs.recommended,
+  importX.flatConfigs.typescript,
+  {
+    plugins: {
+      'import-x': importX
+    },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.es2021
+      },
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        project: true
       }
-    ],
-    "operator-linebreak": [2, "after"],
-    "@typescript-eslint/indent": [
-      "error", 2,
-      {
-        "SwitchCase": 1,
-        "FunctionExpression": {
-          "parameters": "first"
+    },
+    rules: {
+      '@stylistic/comma-dangle': ['error', 'never'],
+      'import-x/prefer-default-export': 'off',
+      'import-x/no-extraneous-dependencies': ['error', { devDependencies: true }],
+      '@stylistic/lines-between-class-members': [
+        'error', 'always',
+        {
+          exceptAfterSingleLine: true
         }
-      }
-    ],
-    "arrow-parens": ["error", "as-needed"],
-    "max-len": ["warn", 120],
-    "@typescript-eslint/no-inferrable-types": "off",
-    "no-underscore-dangle": ["error", {"allowAfterThis": true}],
-    "prefer-destructuring": ["off"],
-    "@typescript-eslint/no-unused-expressions": [2, {"allowTernary": true}],
-    "no-plusplus": ["error", {"allowForLoopAfterthoughts": true}],
-    "no-param-reassign": ["error", {"props": false}],
-    "@typescript-eslint/explicit-member-accessibility": [
-      "error",
-      {
-        accessibility: 'no-public',
-        overrides: {
-          accessors: 'no-public',
-          constructors: 'no-public',
-          methods: 'no-public',
-          properties: 'no-public',
-          parameterProperties: 'no-public'
+      ],
+      '@stylistic/operator-linebreak': [2, 'after'],
+      '@stylistic/indent': [
+        'error', 2,
+        {
+          SwitchCase: 1,
+          FunctionExpression: {
+            parameters: 'first'
+          }
         }
-      }
-    ],
-    "no-use-before-define": ["off"],
-    "@typescript-eslint/no-use-before-define": ["off"],
-    "object-shorthand": ["off"],
-    "function-paren-newline": ["off"]
+      ],
+      'arrow-parens': ['error', 'as-needed'],
+      'max-len': ['warn', 120],
+      '@typescript-eslint/no-inferrable-types': 'off',
+      'no-underscore-dangle': ['error', { allowAfterThis: true }],
+      'prefer-destructuring': ['off'],
+      '@typescript-eslint/no-unused-expressions': [2, { allowTernary: true }],
+      'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
+      'no-param-reassign': ['error', { props: false }],
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        {
+          accessibility: 'no-public',
+          overrides: {
+            accessors: 'no-public',
+            constructors: 'no-public',
+            methods: 'no-public',
+            properties: 'no-public',
+            parameterProperties: 'no-public'
+          }
+        }
+      ],
+      'no-use-before-define': ['off'],
+      '@typescript-eslint/no-use-before-define': ['off'],
+      'object-shorthand': ['off'],
+      'function-paren-newline': ['off'],
+      'sonarjs/no-duplicate-string': 'off'
+    }
   }
-};
+);

--- a/javascript.js
+++ b/javascript.js
@@ -1,37 +1,40 @@
-module.exports = {
-  env: {
-    browser: true,
-    es2021: true
-  },
-  extends: [
-    'airbnb-base'
-  ],
-  parserOptions: {
-    ecmaVersion: 12,
-    sourceType: 'module'
-  },
-  rules: {
-    'comma-dangle': ['error', 'never'],
-    'arrow-parens': ['error', 'as-needed'],
-    'max-len': ['warn', 120],
-    indent: [
-      'error', 2,
-      {
-        SwitchCase: 1,
-        FunctionExpression: {
-          parameters: 'first'
-        }
-      }
-    ],
-    'prefer-destructuring': ['error', {
-      VariableDeclarator: {
-        array: false,
-        object: false
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.es2021
       },
-      AssignmentExpression: {
-        array: false,
-        object: false
-      }
-    }]
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
+    rules: {
+      'comma-dangle': ['error', 'never'],
+      'arrow-parens': ['error', 'as-needed'],
+      'max-len': ['warn', 120],
+      indent: [
+        'error', 2,
+        {
+          SwitchCase: 1,
+          FunctionExpression: {
+            parameters: 'first'
+          }
+        }
+      ],
+      'prefer-destructuring': ['error', {
+        VariableDeclarator: {
+          array: false,
+          object: false
+        },
+        AssignmentExpression: {
+          array: false,
+          object: false
+        }
+      }]
+    }
   }
-};
+];

--- a/package.json
+++ b/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@iqb/eslint-config",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "ESLint rules for javascript and typescript development",
+  "type": "module",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./javascript": "./javascript.js"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "test": "mocha tests/**/*.spec.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/iqb-berlin/eslint-config.git"
@@ -18,9 +27,21 @@
   },
   "homepage": "https://github.com/iqb-berlin/eslint-config#readme",
   "peerDependencies": {
-    "eslint": "^8.57.0",
-    "@typescript-eslint/parser": "^7.2.0",
-    "@typescript-eslint/eslint-plugin": "^7.2.0",
-    "eslint-config-airbnb-typescript": "^18.0.0"
+    "eslint": "^9.0.0",
+    "typescript-eslint": "^8.0.0",
+    "@eslint/js": "^9.0.0",
+    "globals": "^15.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^11.0.0",
+    "eslint": "^9.0.0",
+    "typescript-eslint": "^8.0.0",
+    "@eslint/js": "^9.0.0",
+    "globals": "^15.0.0",
+    "eslint-plugin-sonarjs": "^3.0.0",
+    "eslint-plugin-jsdoc": "^50.0.0",
+    "eslint-plugin-perfectionist": "^4.0.0",
+    "@stylistic/eslint-plugin": "^4.0.0",
+    "eslint-plugin-import-x": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iqb/eslint-config",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "ESLint rules for javascript and typescript development",
   "type": "module",
   "main": "index.js",
@@ -9,8 +9,7 @@
     "./javascript": "./javascript.js"
   },
   "scripts": {
-    "lint": "eslint .",
-    "test": "mocha tests/**/*.spec.js"
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",
@@ -27,21 +26,20 @@
   },
   "homepage": "https://github.com/iqb-berlin/eslint-config#readme",
   "peerDependencies": {
-    "eslint": "^9.0.0",
+    "eslint": "^9.0.0 || ^10.0.0",
     "typescript-eslint": "^8.0.0",
-    "@eslint/js": "^9.0.0",
+    "@eslint/js": "^9.0.0 || ^10.0.0",
     "globals": "^15.0.0"
   },
   "devDependencies": {
-    "mocha": "^11.0.0",
-    "eslint": "^9.0.0",
+    "eslint": "^10.2.1",
     "typescript-eslint": "^8.0.0",
-    "@eslint/js": "^9.0.0",
+    "@eslint/js": "^10.0.1",
     "globals": "^15.0.0",
-    "eslint-plugin-sonarjs": "^3.0.0",
-    "eslint-plugin-jsdoc": "^50.0.0",
-    "eslint-plugin-perfectionist": "^4.0.0",
-    "@stylistic/eslint-plugin": "^4.0.0",
-    "eslint-plugin-import-x": "^4.0.0"
+    "eslint-plugin-sonarjs": "^4.0.3",
+    "eslint-plugin-jsdoc": "^62.9.0",
+    "eslint-plugin-perfectionist": "^5.9.0",
+    "@stylistic/eslint-plugin": "^5.10.0",
+    "eslint-plugin-import-x": "^4.16.2"
   }
 }


### PR DESCRIPTION
## Summary
- migrate package output to ESM + ESLint flat config (`index.js` and `javascript.js`)
- finalize dependency ranges for ESLint 9 **and** 10 compatibility
- add migration-focused README guidance from legacy `.eslintrc*` style to `eslint.config.js`
- mark release as breaking (`3.0.0`) due format migration

## Why
Issue #10 requests completion of the flat-config migration and a clear compatibility path for ESLint 10.

## Validation
Ran a smoke validation by installing dependencies and linting both TS and JS samples with the exported configs via `ESLint` API:
- TypeScript config (`@iqb/eslint-config`)
- JavaScript config (`@iqb/eslint-config/javascript`)

Result: no fatal configuration/runtime errors during lint execution.

## Notes
- This PR focuses on migration + compatibility + docs.
- CI fixture tests are handled separately in the PR for issue #11.

Closes #10
