### PR TITLE
[codex] Add CI smoke tests for shared ESLint config

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,29 @@
+name: Lint Smoke Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20.x', '22.x']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run smoke tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ to your package.json and make sure the path points to your main *tsconfig.json* 
   }
 },
 ```
+
+## Internal Development
+
+Run smoke tests for both TypeScript and JavaScript fixtures:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@iqb/eslint-config",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "ESLint rules for javascript and typescript development",
   "main": "index.js",
+  "scripts": {
+    "test": "mocha tests/**/*.spec.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/iqb-berlin/eslint-config.git"
@@ -22,5 +25,14 @@
     "@typescript-eslint/parser": "^7.2.0",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "eslint-config-airbnb-typescript": "^18.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^11.7.4",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "eslint-config-airbnb-typescript": "^18.0.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.32.0"
   }
 }

--- a/tests/config.spec.js
+++ b/tests/config.spec.js
@@ -1,0 +1,42 @@
+const assert = require('node:assert');
+const path = require('node:path');
+const { ESLint } = require('eslint');
+const tsConfig = require('../index');
+const jsConfig = require('../javascript');
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+const tsFixtureDir = path.join(fixturesDir, 'typescript');
+const jsFixtureDir = path.join(fixturesDir, 'javascript');
+
+describe('ESLint Config Smoke Tests', () => {
+  it('loads TypeScript config and lints fixture without fatal errors', async () => {
+    const eslint = new ESLint({
+      cwd: tsFixtureDir,
+      useEslintrc: false,
+      overrideConfig: {
+        ...tsConfig,
+        parserOptions: {
+          ...tsConfig.parserOptions,
+          project: './tsconfig.json',
+          tsconfigRootDir: tsFixtureDir
+        }
+      }
+    });
+
+    const results = await eslint.lintFiles(['sample.ts']);
+    const fatalErrors = results.flatMap(result => result.messages).filter(message => message.fatal);
+    assert.strictEqual(fatalErrors.length, 0, `Fatal TypeScript lint errors: ${JSON.stringify(fatalErrors)}`);
+  });
+
+  it('loads JavaScript config and lints fixture without fatal errors', async () => {
+    const eslint = new ESLint({
+      cwd: jsFixtureDir,
+      useEslintrc: false,
+      overrideConfig: jsConfig
+    });
+
+    const results = await eslint.lintFiles(['sample.js']);
+    const fatalErrors = results.flatMap(result => result.messages).filter(message => message.fatal);
+    assert.strictEqual(fatalErrors.length, 0, `Fatal JavaScript lint errors: ${JSON.stringify(fatalErrors)}`);
+  });
+});

--- a/tests/fixtures/javascript/sample.js
+++ b/tests/fixtures/javascript/sample.js
@@ -1,0 +1,1 @@
+export const sum = (a, b) => a + b;

--- a/tests/fixtures/typescript/sample.ts
+++ b/tests/fixtures/typescript/sample.ts
@@ -1,0 +1,7 @@
+export class Sample {
+  private name: string = 'test';
+
+  getName() {
+    return this.name;
+  }
+}

--- a/tests/fixtures/typescript/tsconfig.json
+++ b/tests/fixtures/typescript/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true
+  },
+  "include": ["sample.ts"]
+}


### PR DESCRIPTION
## Summary
- add smoke fixtures for both TypeScript and JavaScript
- add Mocha smoke tests that lint both fixtures and assert no fatal config/runtime errors
- add GitHub Actions workflow to run smoke tests on push/PR
- run workflow on a Node matrix (`20.x`, `22.x`)

## Why
Issue #11 asks for CI safety checks to ensure this shared config package stays usable across projects.

## Validation
Local run:
- `npm install`
- `npm test`

Result:
- 2 passing tests (TS fixture + JS fixture)

Closes #11
