### PR TITLE
[codex] Add governance docs and issue config for shared ESLint

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Lint Policy
+    url: https://github.com/iqb-berlin/eslint-config/blob/master/docs/lint-policy.md
+    about: Lese zuerst die Governance und Entscheidungsregeln fuer Regel-Aenderungen.
+  - name: Consumer CI Checklist
+    url: https://github.com/iqb-berlin/eslint-config/blob/master/docs/consumer-ci-checklist.md
+    about: Nutze die Checkliste fuer Einfuehrung und CI-Rollout in Consumer-Repositories.

--- a/.github/ISSUE_TEMPLATE/rule-change.yml
+++ b/.github/ISSUE_TEMPLATE/rule-change.yml
@@ -1,0 +1,105 @@
+name: Rule Change
+description: Vorschlag fuer neue, geaenderte oder deaktivierte ESLint-Regeln
+title: "rule-change: <kurzer titel>"
+labels:
+  - rule-change
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Danke fuer deinen Vorschlag.
+        Bitte so konkret wie moeglich ausfuellen, damit wir schnell entscheiden koennen.
+
+  - type: dropdown
+    id: change_type
+    attributes:
+      label: Typ der Aenderung
+      options:
+        - Regel aktivieren
+        - Regel deaktivieren
+        - Regellevel aendern (error/warn/off)
+        - Regeloptionen aendern
+        - Neue Plugin-Regel einfuehren
+    validations:
+      required: true
+
+  - type: input
+    id: rule_name
+    attributes:
+      label: Betroffene Regel
+      description: z. B. @typescript-eslint/no-floating-promises
+      placeholder: plugin/rule-name
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problemstellung
+      description: Welches konkrete Problem loesen wir?
+      placeholder: Kurze Beschreibung mit Kontext
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Konkreter Vorschlag
+      description: Welche Regelkonfiguration schlaegst du vor?
+      placeholder: |
+        Beispiel:
+        "rules": {
+          "@typescript-eslint/no-floating-promises": "error"
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Codebeispiele (vorher/nachher)
+      description: Kleine Snippets oder Links auf Stellen im Code
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Empfohlenes Level
+      options:
+        - error
+        - warn
+        - off
+    validations:
+      required: true
+
+  - type: dropdown
+    id: semver_impact
+    attributes:
+      label: Vermuteter SemVer-Impact
+      options:
+        - patch
+        - minor
+        - major
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollout_risk
+    attributes:
+      label: Rollout-Risiko und Migrationsaufwand
+      description: Welche Repos sind wahrscheinlich betroffen und wie aufwaendig ist die Umstellung?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checkliste
+      options:
+        - label: Ich habe geprueft, ob es bereits ein aehnliches Rule-Change-Issue gibt
+          required: true
+        - label: Ich habe mindestens ein reales Beispiel aus einem IQB-Repository angegeben
+          required: true
+        - label: Ich kann bei Bedarf einen PR oder Testfall beisteuern
+          required: false

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ npm run lint
 npm run test
 ```
 
+## Governance und Teamarbeit
+
+- Lint-Governance und Entscheidungsregeln:
+  - [`docs/lint-policy.md`](docs/lint-policy.md)
+- CI-Checkliste fuer Consumer-Repositories:
+  - [`docs/consumer-ci-checklist.md`](docs/consumer-ci-checklist.md)
+- Vorlage fuer Regel-Aenderungsantraege:
+  - [`.github/ISSUE_TEMPLATE/rule-change.yml`](.github/ISSUE_TEMPLATE/rule-change.yml)
+
 ## Troubleshooting
 
 In case you are not using *Solution Style tsconfig.json* files, make sure the `project` path in `parserOptions` points to your main `tsconfig.json` file.

--- a/docs/consumer-ci-checklist.md
+++ b/docs/consumer-ci-checklist.md
@@ -1,0 +1,101 @@
+# CI Checklist for Consumer Repositories
+
+Diese Checkliste hilft Teams, `@iqb/eslint-config` stabil und einheitlich in Anwendungen zu nutzen.
+
+## 1. Paketinstallation
+
+```bash
+npm install --save-dev @iqb/eslint-config
+```
+
+## 2. ESLint Flat Config anlegen
+
+TypeScript (`eslint.config.js`):
+
+```js
+import iqbConfig from '@iqb/eslint-config';
+
+export default [
+  ...iqbConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname
+      }
+    }
+  }
+];
+```
+
+JavaScript (`eslint.config.js`):
+
+```js
+import iqbJavaScriptConfig from '@iqb/eslint-config/javascript';
+
+export default [...iqbJavaScriptConfig];
+```
+
+## 3. NPM Scripts vereinheitlichen
+
+```json
+{
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "ci:lint": "npm run lint"
+  }
+}
+```
+
+## 4. GitHub Actions einbinden
+
+```yaml
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run ci:lint
+```
+
+## 5. Pre-Commit (empfohlen)
+
+`lint-staged` + `husky` fuer schnelles lokales Feedback:
+
+```json
+{
+  "lint-staged": {
+    "*.{js,cjs,mjs,ts,tsx}": "eslint --fix"
+  }
+}
+```
+
+## 6. Rollout in bestehenden Projekten
+
+- Erst einmalig `npm run lint -- --fix` ausfuehren
+- Restliche Verstosse gezielt bereinigen
+- Falls noetig temporaer einzelne Regeln als `warn` konfigurieren
+- Lokale Sonderregeln mit Begruendung dokumentieren
+
+## 7. Upgrade-Prozess
+
+- Neue `@iqb/eslint-config` Version in einer technischen PR anheben
+- Changelog/Migrationshinweise pruefen
+- CI + lokale Lint-Checks pruefen
+- Bei Abweichungen Rule-Change-Issue im Config-Repo anlegen

--- a/docs/lint-policy.md
+++ b/docs/lint-policy.md
@@ -1,0 +1,67 @@
+# Lint Policy for IQB Projects
+
+## Ziel
+
+Dieses Repository ist die zentrale Quelle fuer gemeinsame ESLint-Regeln in IQB-Projekten.
+Die Policy sorgt dafuer, dass Regeln teamweit einheitlich, transparent und planbar weiterentwickelt werden.
+
+## Geltungsbereich
+
+- Alle aktiven IQB-JavaScript- und TypeScript-Repositories, die `@iqb/eslint-config` verwenden
+- Neue Projekte sollen standardmaessig auf diesem Config-Paket aufsetzen
+
+## Rollen
+
+- Maintainer (2-3 Personen): pflegen Regeln, priorisieren Aenderungen, verantworten Releases
+- Contributors: schlagen Regel-Aenderungen vor und liefern technische Umsetzung
+- Consumer Teams: melden Friktionen, testen Canaries, uebernehmen neue Versionen in ihren Anwendungen
+
+## Entscheidungsprinzipien fuer Regeln
+
+- `error`: Fehlerpraevention, Sicherheits-/Correctness-Risiken, klare Defekte
+- `warn`: Lesbarkeit, Wartbarkeit, graduelle Qualitaetsverbesserung
+- `off`: wenn Regel wenig Nutzen hat oder in IQB-Projekten systematisch Fehlalarme erzeugt
+
+Regeln sollen bevorzugt:
+
+- autofixbar sein
+- reproduzierbar in mehreren Repos Mehrwert liefern
+- nicht stark framework-spezifisch sein
+
+## Prozess fuer Regel-Aenderungen
+
+1. Rule-Change-Issue mit Template erstellen
+2. Problem und konkrete Beispiele dokumentieren
+3. Einschaetzung fuer Rollout-Risiko und SemVer angeben
+4. PR mit Aenderung und Tests erstellen
+5. Mindestens ein Consumer-Projekt als Canary pruefen
+6. Release inkl. Changelog und Migrationshinweis veroeffentlichen
+7. Adoption in Consumer-Repos nach festem Rollout-Plan
+
+## SemVer-Regeln
+
+- `major`: breaking changes, neue strenge Defaults, Flat-Config-/Engine-Wechsel
+- `minor`: neue Regeln als `warn`, neue optionale Exports, nicht-brechende Verbesserungen
+- `patch`: Bugfixes, Dokumentation, Test-/Workflow-Fixes ohne Verhaltensbruch
+
+## Release-Rhythmus
+
+- Regelmaessig, z. B. monatlich oder bei Bedarf
+- Security- oder Build-Break-Fixes koennen ad hoc als Patch erscheinen
+
+## Override-Policy in Consumer-Repos
+
+- Lokale Overrides sind erlaubt, aber mit kurzer Begruendung im Projekt (`eslint.config.js` Kommentar oder ADR)
+- Dauerhafte Abweichungen sollen als Rule-Change-Issue zurueck in dieses Repo gespiegelt werden
+
+## Definition of Done fuer Regel-PRs
+
+- Regelbegruendung und Risikoeinschaetzung dokumentiert
+- Lint/Test-Workflow gruen
+- Canary-Validierung in mindestens einem realen Consumer-Repo erfolgt
+- Release Notes/Migrationshinweise vorbereitet (falls noetig)
+
+## Entscheidungsmodus bei Uneinigkeit
+
+- Wenn kein Konsens erreicht wird: Maintainer-Entscheid mit kurzer Begruendung im Issue
+- Ziel ist pragmatische Einheitlichkeit statt perfekter individueller Stilpraeferenz


### PR DESCRIPTION
## Summary
- add governance policy for shared ESLint evolution
- add consumer CI rollout checklist for IQB application repositories
- add GitHub issue template for rule-change proposals
- add issue template config with links to governance/checklist docs
- link all governance assets from README

## Why
This makes cross-team collaboration around lint rules explicit, repeatable, and easier to moderate.

## Included files
- `docs/lint-policy.md`
- `docs/consumer-ci-checklist.md`
- `.github/ISSUE_TEMPLATE/rule-change.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `README.md`
